### PR TITLE
Fix hang with trailing comment

### DIFF
--- a/lib/hxml/Parser.hx
+++ b/lib/hxml/Parser.hx
@@ -46,7 +46,7 @@ class Parser {
 				case "#":
 					// We are not doing anything with the comments now, so just
 					// consume up to the end of the line and throw them away.
-					while ((char = text.charAt(cursor++)) != "\n" && char != "\r") { }
+					while ((char = text.charAt(cursor++)) != "\n" && char != "\r" && char != "") { }
 					cursor -= 1;
 
 					// Here to catch if this comment was on a line with a command

--- a/test/src/TestParser.hx
+++ b/test/src/TestParser.hx
@@ -68,6 +68,17 @@ class TestParser extends utest.Test {
 			assertLineEq(Line.Command("--js", "bin/contact.js"), hxml.sets[2].lines[2]);
 			assertLineEq(Line.Command("--main", "website.ContactPage"), hxml.sets[2].lines[3]);
 		}
+
+		function testTrailingComment() {
+
+			var hxml = load("test/test-files/TrailingComment.hxml");
+
+			Assert.equals(1, hxml.sets.length);
+			assertLineEq(Line.Command("--class-path", "src"), hxml.sets[0].lines[0]);
+			assertLineEq(Line.Command("--dce", "full"), hxml.sets[0].lines[1]);
+			assertLineEq(Line.Command("--js", "bin/homepage.js"), hxml.sets[0].lines[2]);
+			assertLineEq(Line.Command("--main", "website.HomePage"), hxml.sets[0].lines[3]);
+		}
 }
 
 inline function assertLineEq(a : Line, b : Line) {

--- a/test/test-files/TrailingComment.hxml
+++ b/test/test-files/TrailingComment.hxml
@@ -1,0 +1,6 @@
+# example taken from the haxe website
+--class-path src
+--dce full
+--js bin/homepage.js
+--main website.HomePage
+# trailing comment


### PR DESCRIPTION
Trying to parse a hxml file with a trailing comment would hang forever.